### PR TITLE
Modifiche per implementare TimelineDao

### DIFF
--- a/src/main/java/it/pagopa/pn/api/dto/notification/Notification.java
+++ b/src/main/java/it/pagopa/pn/api/dto/notification/Notification.java
@@ -28,7 +28,7 @@ import java.util.List;
 public class Notification {
 
     @Schema( description = "L'Identificativo Univoco Notifica assegnato da PN")
-    @JsonView(value = { NotificationJsonViews.Sent.class })
+    @JsonView(value = { NotificationJsonViews.Sent.class, NotificationJsonViews.Received.class })
     private String iun;
 
     @Schema( description = "Numero di protocollo che la PA mittente assegna alla notifica stessa" )

--- a/src/main/java/it/pagopa/pn/api/dto/notification/timeline/NotificationPathChooseDetails.java
+++ b/src/main/java/it/pagopa/pn/api/dto/notification/timeline/NotificationPathChooseDetails.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Builder(toBuilder = true)
 @EqualsAndHashCode
 @ToString
-public class NotificationPathChooseDetails {
+public class NotificationPathChooseDetails implements TimelineElementDetails {
 
     @Schema( description = "codice fiscale destinatario")
     String taxId;

--- a/src/main/java/it/pagopa/pn/api/dto/notification/timeline/ReceivedDetails.java
+++ b/src/main/java/it/pagopa/pn/api/dto/notification/timeline/ReceivedDetails.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Builder(toBuilder = true)
 @EqualsAndHashCode
 @ToString
-public class ReceivedDetails {
+public class ReceivedDetails implements TimelineElementDetails {
 
     @Schema( description = "informazioni sui destinatari")
     private List<NotificationRecipient> recipients;

--- a/src/main/java/it/pagopa/pn/api/dto/notification/timeline/SendDigitalDetails.java
+++ b/src/main/java/it/pagopa/pn/api/dto/notification/timeline/SendDigitalDetails.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Builder(builderMethodName = "sendBuilder", toBuilder = true)
 @EqualsAndHashCode
 @ToString
-public class SendDigitalDetails {
+public class SendDigitalDetails implements TimelineElementDetails {
 
     @Schema( description = "Codice Fiscale destinatario notifica digitale")
     private String taxId;

--- a/src/main/java/it/pagopa/pn/api/dto/notification/timeline/TimelineElement.java
+++ b/src/main/java/it/pagopa/pn/api/dto/notification/timeline/TimelineElement.java
@@ -1,6 +1,7 @@
 package it.pagopa.pn.api.dto.notification.timeline;
 
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -14,11 +15,17 @@ import java.time.Instant;
 @ToString
 public class TimelineElement {
 
+    @JsonIgnore
+    private String iun;
+
+    @Schema( description = "Insieme allo IUN della notifica definisce in maniera univoca l'elemento di timeline")
+    private String elementId;
+
     @Schema( description = "Momento in cui avviene l'evento desritto in questo elemento di timeline")
     private Instant timestamp;
 
     @Schema( description = "tipo di evento registrato")
-    private TimelineElementEventCategory eventCategory;
+    private TimelineElementCategory category;
 
     @Schema( description = "dettagli sull'evento: variano in base al \"eventCategory\"",
             oneOf = {

--- a/src/main/java/it/pagopa/pn/api/dto/notification/timeline/TimelineElement.java
+++ b/src/main/java/it/pagopa/pn/api/dto/notification/timeline/TimelineElement.java
@@ -15,6 +15,8 @@ import java.time.Instant;
 @ToString
 public class TimelineElement {
 
+    // - Today (2021-08-25) this entity is planned to be used only as child of Notification.
+    //   This field is not useful because it is a repetition of the notification iun.
     @JsonIgnore
     private String iun;
 

--- a/src/main/java/it/pagopa/pn/api/dto/notification/timeline/TimelineElementCategory.java
+++ b/src/main/java/it/pagopa/pn/api/dto/notification/timeline/TimelineElementCategory.java
@@ -1,0 +1,18 @@
+package it.pagopa.pn.api.dto.notification.timeline;
+
+public enum TimelineElementCategory {
+    RECEIVED_ACK( ReceivedDetails.class ),
+    NOTIFICATION_PATH_CHOOSE( NotificationPathChooseDetails.class ),
+    SEND_DIGITAL_DOMICILE( SendDigitalDetails.class ),
+    SEND_DIGITAL_DOMICILE_FEEDBACK( SendDigitalFeedbackDetails.class );
+
+    private final Class< ? extends TimelineElementDetails> detailsJavaClass;
+
+    private TimelineElementCategory(Class<? extends TimelineElementDetails> detailsJavaClass) {
+        this.detailsJavaClass = detailsJavaClass;
+    }
+
+    public Class< ? extends TimelineElementDetails> getDetailsJavaClass() {
+        return this.detailsJavaClass;
+    }
+}

--- a/src/main/java/it/pagopa/pn/api/dto/notification/timeline/TimelineElementEventCategory.java
+++ b/src/main/java/it/pagopa/pn/api/dto/notification/timeline/TimelineElementEventCategory.java
@@ -1,8 +1,0 @@
-package it.pagopa.pn.api.dto.notification.timeline;
-
-public enum TimelineElementEventCategory {
-    RECEIVED_ACK,
-    NOTIFICATION_PATH_CHOOSE,
-    SEND_DIGITAL_DOMICILE,
-    SEND_DIGITAL_DOMICILE_FEEDBACK,
-}


### PR DESCRIPTION
l'enum è stato rinominato e le classi di dettaglio ora implementano l'interfaccia TimelineElementDetails, prima non lo facevano ma era un errore.

Aggiunto campo sentAt alla notifica (indispensabile per memorizzare l'orario di ricezione)

Aggiunto campo elementId e iun agli elementi di timeline (indispensabili per identificarli quando non agganciati a una notifica)