### PR TITLE
PN-2012 spostante classi SQS dal commons al model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<relativePath/>
 	</parent>
 	<artifactId>pn-model</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 	<name>pn-model</name>
 	<description>Modello dati Piattaforma Notifiche</description>
 
@@ -43,6 +43,10 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sqs</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/it/pagopa/pn/api/dto/events/AbstractSqsMomProducer.java
+++ b/src/main/java/it/pagopa/pn/api/dto/events/AbstractSqsMomProducer.java
@@ -1,0 +1,91 @@
+package it.pagopa.pn.api.dto.events;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static it.pagopa.pn.api.dto.events.StandardEventHeader.*;
+
+public abstract class AbstractSqsMomProducer<T extends GenericEvent> implements MomProducer<T> {
+
+    private final SqsClient sqsClient;
+    private final ObjectWriter objectWriter;
+    private final String queueUrl;
+
+    protected AbstractSqsMomProducer(SqsClient sqsClient, String topic, ObjectMapper objectMapper, Class<T> msgClass) {
+        this.sqsClient = sqsClient;
+        Class<?> payloadClass = getPayloadClass(msgClass);
+        this.objectWriter = objectMapper.writerFor(payloadClass);
+
+        this.queueUrl = getQueueUrl(sqsClient, topic);
+    }
+
+    @NotNull
+    private Class<?> getPayloadClass(Class<T> msgClass) {
+        try {
+            return msgClass.getDeclaredField("payload").getType();
+        } catch (NoSuchFieldException exc) {
+            throw new RuntimeException( "Preparing sqs producer " + this.getClass(), exc );
+        }
+    }
+
+    private String getQueueUrl(SqsClient sqsClient, String topic) {
+        return sqsClient.getQueueUrl(GetQueueUrlRequest.builder().queueName(topic).build()).queueUrl();
+    }
+
+    @Override
+    public void push(List<T> msges) {
+        
+        sqsClient.sendMessageBatch(SendMessageBatchRequest.builder()
+                .queueUrl(this.queueUrl)
+                .entries(msges.stream()
+                        .map(msg -> SendMessageBatchRequestEntry.builder()
+                            .messageBody(toJson(msg.getPayload()))
+                            .id(msg.getHeader().getEventId())
+                            .messageAttributes(getSqSHeader(msg.getHeader()))
+                            .build()
+                        )
+                        .collect(Collectors.toList()))
+                .build());
+
+    }
+
+    private String toJson(Object obj) {
+        try {
+            return objectWriter.writeValueAsString(obj);
+        } catch (JsonProcessingException exc) {
+            throw new IllegalStateException(exc);
+        }
+    }
+
+    private Map<String, MessageAttributeValue> getSqSHeader(StandardEventHeader header) {
+               
+        Map<String, MessageAttributeValue> map = new HashMap<>();
+        
+        map.put(PN_EVENT_HEADER_IUN, newStringAttributeValue(header.getIun()));
+        map.put(PN_EVENT_HEADER_EVENT_ID, newStringAttributeValue(header.getEventId()));
+        map.put(PN_EVENT_HEADER_EVENT_TYPE, newStringAttributeValue(header.getEventType()));
+        map.put(PN_EVENT_HEADER_CREATED_AT, newStringAttributeValue(header.getCreatedAt().toString()));
+        map.put(PN_EVENT_HEADER_PUBLISHER, newStringAttributeValue(header.getPublisher()));
+       
+        return map;
+    }
+
+    private MessageAttributeValue newStringAttributeValue(String value) {
+        return MessageAttributeValue.builder()
+                .dataType("String")
+                .stringValue(value)
+                .build();
+    }
+}

--- a/src/main/java/it/pagopa/pn/api/dto/events/MomConsumer.java
+++ b/src/main/java/it/pagopa/pn/api/dto/events/MomConsumer.java
@@ -1,0 +1,10 @@
+package it.pagopa.pn.api.dto.events;
+
+import java.time.Duration;
+import java.util.List;
+
+public interface MomConsumer<T> {
+
+    List<T> poll(Duration maxPollTime);
+
+}

--- a/src/main/java/it/pagopa/pn/api/dto/events/MomProducer.java
+++ b/src/main/java/it/pagopa/pn/api/dto/events/MomProducer.java
@@ -1,0 +1,13 @@
+package it.pagopa.pn.api.dto.events;
+
+import java.util.Collections;
+import java.util.List;
+
+public interface MomProducer<T extends GenericEvent> {
+
+    void push(List<T> messages);
+
+    default void push(T message) {
+        push( Collections.singletonList( message ));
+    }
+}

--- a/src/test/java/it/pagopa/pn/api/dto/notification/address/AbstractSqsMomProducerTest.java
+++ b/src/test/java/it/pagopa/pn/api/dto/notification/address/AbstractSqsMomProducerTest.java
@@ -1,0 +1,82 @@
+package it.pagopa.pn.api.dto.notification.address;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.pn.api.dto.events.AbstractSqsMomProducer;
+import it.pagopa.pn.api.dto.events.MomProducer;
+import it.pagopa.pn.api.dto.events.PnDeliveryNewNotificationEvent;
+import it.pagopa.pn.api.dto.events.StandardEventHeader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+
+class AbstractSqsMomProducerTest {
+
+    MomProducer<PnDeliveryNewNotificationEvent> producer;
+
+    SqsClient sqsClient;
+
+    @BeforeEach
+    public void init() {
+        sqsClient = new SqsClientTest();
+        String topicName = "topic-test";
+        ObjectMapper objectMapper = new ObjectMapper();
+        producer = new ProducerTest(sqsClient, topicName, objectMapper);
+    }
+
+    @Test
+    void pushTest() {
+        PnDeliveryNewNotificationEvent message = buildMessage();
+        assertDoesNotThrow(() -> producer.push(message));
+    }
+
+    private PnDeliveryNewNotificationEvent buildMessage() {
+        return PnDeliveryNewNotificationEvent.builder()
+                .header(StandardEventHeader.builder()
+                        .iun("test-iun")
+                        .eventId("event-id-test")
+                        .createdAt(Instant.now())
+                        .eventType("event-type-test")
+                        .build())
+                .payload(PnDeliveryNewNotificationEvent.Payload.builder().paId("pa-id-test").build())
+                .build();
+    }
+
+
+    private class ProducerTest extends AbstractSqsMomProducer<PnDeliveryNewNotificationEvent> {
+
+        protected ProducerTest(SqsClient sqsClient, String topic, ObjectMapper objectMapper) {
+            super(sqsClient, topic, objectMapper, PnDeliveryNewNotificationEvent.class);
+        }
+    }
+
+    private class SqsClientTest implements SqsClient {
+
+        @Override
+        public String serviceName() {
+            return "test";
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public GetQueueUrlResponse getQueueUrl(GetQueueUrlRequest getQueueUrlRequest) throws QueueDoesNotExistException, AwsServiceException, SdkClientException, SqsException {
+            return GetQueueUrlResponse.builder().queueUrl("test-url").build();
+        }
+
+        @Override
+        public SendMessageBatchResponse sendMessageBatch(SendMessageBatchRequest sendMessageBatchRequest) throws TooManyEntriesInBatchRequestException, EmptyBatchRequestException, BatchEntryIdsNotDistinctException, BatchRequestTooLongException, InvalidBatchEntryIdException, software.amazon.awssdk.services.sqs.model.UnsupportedOperationException, AwsServiceException, SdkClientException, SqsException {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Aggiunge classi di pn-commons che dipendevano da pn-model, eliminando la dipendenza tra i due moduli.