### PR TITLE
Feature/pn 3013 spring boot 27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>it.pagopa.pn</groupId>
 		<artifactId>pn-parent</artifactId>
-		<version>2.0.1-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 		<relativePath>../pn-parent</relativePath>
 	</parent>
 	<artifactId>pn-model</artifactId>
@@ -15,7 +15,7 @@
 		<connection>${git.conn}</connection>
 		<developerConnection>${git.devConn}</developerConnection>
 		<url>${git.url}</url>
-		<tag>v1.0.0</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
 		<jacoco.min.line.cover.ratio>0.01</jacoco.min.line.cover.ratio>
 	</properties>
 
-
 	<dependencies>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,10 +88,6 @@
 
 			<dependencies>
 				<dependency>
-					<groupId>org.springframework.boot</groupId>
-					<artifactId>spring-boot-starter-webflux</artifactId>
-				</dependency>
-				<dependency>
 					<groupId>org.springdoc</groupId>
 					<artifactId>springdoc-openapi-webflux-ui</artifactId>
 					<version>1.5.13</version>
@@ -102,14 +98,6 @@
 					<plugin>
 						<groupId>org.springframework.boot</groupId>
 						<artifactId>spring-boot-maven-plugin</artifactId>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<configuration>
-							<source>${java.version}</source>
-							<target>${java.version}</target>
-						</configuration>
 					</plugin>
 				</plugins>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath>../pn-parent</relativePath>
 	</parent>
 	<artifactId>pn-model</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.0.2-SNAPSHOT</version>
 	<name>pn-model</name>
 	<description>Modello dati Piattaforma Notifiche</description>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>it.pagopa.pn</groupId>
 		<artifactId>pn-parent</artifactId>
-		<version>1.0.1-SNAPSHOT</version>
+		<version>1.0.2-SNAPSHOT</version>
 		<relativePath>../pn-parent</relativePath>
 	</parent>
 	<artifactId>pn-model</artifactId>


### PR DESCRIPTION
Passaggio a java 17 e Spring Boot 2.7.6. Eliminate dipendenze superflue.
Questa PR può essere mergiata SOLO dopo questa:
https://github.com/pagopa/pn-parent/pull/16