### PR TITLE
Split F24 event bridge events

### DIFF
--- a/src/main/java/it/pagopa/pn/api/dto/events/PnF24MetadataValidationEndEvent.java
+++ b/src/main/java/it/pagopa/pn/api/dto/events/PnF24MetadataValidationEndEvent.java
@@ -17,6 +17,7 @@ public class PnF24MetadataValidationEndEvent implements GenericEventBridgeEvent<
     @EqualsAndHashCode
     public static class Detail {
         String cxId;
+        String clientId;
         PnF24MetadataValidationEndEventPayload metadataValidationEnd;
     }
 }

--- a/src/main/java/it/pagopa/pn/api/dto/events/PnF24MetadataValidationEndEvent.java
+++ b/src/main/java/it/pagopa/pn/api/dto/events/PnF24MetadataValidationEndEvent.java
@@ -1,0 +1,22 @@
+package it.pagopa.pn.api.dto.events;
+
+import lombok.*;
+
+@Builder
+@Getter
+@EqualsAndHashCode
+@ToString
+public class PnF24MetadataValidationEndEvent implements GenericEventBridgeEvent<PnF24MetadataValidationEndEvent.Detail> {
+    private Detail detail;
+
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Getter
+    @Builder(toBuilder = true)
+    @ToString
+    @EqualsAndHashCode
+    public static class Detail {
+        String cxId;
+        PnF24MetadataValidationEndEventPayload metadataValidationEnd;
+    }
+}

--- a/src/main/java/it/pagopa/pn/api/dto/events/PnF24PdfSetReadyEvent.java
+++ b/src/main/java/it/pagopa/pn/api/dto/events/PnF24PdfSetReadyEvent.java
@@ -17,6 +17,7 @@ public class PnF24PdfSetReadyEvent implements GenericEventBridgeEvent<PnF24PdfSe
     @EqualsAndHashCode
     public static class Detail {
         String cxId;
+        String clientId;
         PnF24PdfSetReadyEventPayload pdfSetReady;
     }
 }

--- a/src/main/java/it/pagopa/pn/api/dto/events/PnF24PdfSetReadyEvent.java
+++ b/src/main/java/it/pagopa/pn/api/dto/events/PnF24PdfSetReadyEvent.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Getter
 @EqualsAndHashCode
 @ToString
-public class PnF24AsyncEvent implements GenericEventBridgeEvent<PnF24AsyncEvent.Detail> {
+public class PnF24PdfSetReadyEvent implements GenericEventBridgeEvent<PnF24PdfSetReadyEvent.Detail> {
     private Detail detail;
 
     @NoArgsConstructor
@@ -18,6 +18,5 @@ public class PnF24AsyncEvent implements GenericEventBridgeEvent<PnF24AsyncEvent.
     public static class Detail {
         String cxId;
         PnF24PdfSetReadyEventPayload pdfSetReady;
-        PnF24MetadataValidationEndEventPayload metadataValidationEnd;
     }
 }


### PR DESCRIPTION
Separato l'evento PnF24AsyncEvent in 2 Dto diversi. Uno per ogni producer da utilizzare su F24