### PR TITLE
feat(PN-20391): getQueueUrl after constructor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>it.pagopa.pn</groupId>
 		<artifactId>pn-parent</artifactId>
-		<version>2.1.2-SPRINGBOOT3</version>
+		<version>2.2.1-SPRINGBOOT3-PL</version>
 		<relativePath>../pn-parent</relativePath>
 	</parent>
 	<artifactId>pn-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath>../pn-parent</relativePath>
 	</parent>
 	<artifactId>pn-model</artifactId>
-	<version>2.15.0-SPRINGBOOT3-PL</version>
+	<version>2.15.1-SPRINGBOOT3-PL</version>
 	<name>pn-model</name>
 	<description>Modello dati Piattaforma Notifiche</description>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>it.pagopa.pn</groupId>
 		<artifactId>pn-parent</artifactId>
-		<version>2.2.1-SPRINGBOOT3-PL</version>
+		<version>2.3.0-SPRINGBOOT3</version>
 		<relativePath>../pn-parent</relativePath>
 	</parent>
 	<artifactId>pn-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath>../pn-parent</relativePath>
 	</parent>
 	<artifactId>pn-model</artifactId>
-	<version>2.15.1-SPRINGBOOT3-PL</version>
+	<version>2.15.0-SPRINGBOOT3</version>
 	<name>pn-model</name>
 	<description>Modello dati Piattaforma Notifiche</description>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 		<relativePath>../pn-parent</relativePath>
 	</parent>
 	<artifactId>pn-model</artifactId>
-	<version>2.15.0-SPRINGBOOT3</version>
+	<version>2.15.0-SPRINGBOOT3-PL</version>
 	<name>pn-model</name>
 	<description>Modello dati Piattaforma Notifiche</description>
 	<scm>

--- a/src/main/java/it/pagopa/pn/api/dto/events/AbstractSqsFifoMomProducer.java
+++ b/src/main/java/it/pagopa/pn/api/dto/events/AbstractSqsFifoMomProducer.java
@@ -47,7 +47,7 @@ public abstract class AbstractSqsFifoMomProducer<T extends GenericFifoEvent> ext
     public void push(T message) {
         log.debug("Inserting data {} in SQS {} with sendMessage", message, topic);
         SendMessageRequest request = SendMessageRequest.builder()
-                .queueUrl(this.queueUrl)
+                .queueUrl(getQueueUrl())
                 .messageBody(toJson(message.getPayload()))
                 .messageAttributes(getSqSHeader(message.getHeader()))
                 .messageGroupId(message.getMessageGroupId())

--- a/src/main/java/it/pagopa/pn/api/dto/events/AbstractSqsMomProducer.java
+++ b/src/main/java/it/pagopa/pn/api/dto/events/AbstractSqsMomProducer.java
@@ -26,7 +26,7 @@ public abstract class AbstractSqsMomProducer<T extends GenericEvent> implements 
 
     protected final SqsClient sqsClient;
     private final ObjectWriter objectWriter;
-    protected final String queueUrl;
+    private volatile String queueUrl;
     protected final String topic;
     protected int retriesForBatch = N_RETRY_ATTEMPTS;
 
@@ -36,7 +36,7 @@ public abstract class AbstractSqsMomProducer<T extends GenericEvent> implements 
         this.objectWriter = objectMapper.writerFor(payloadClass);
 
         this.topic = topic;
-        this.queueUrl = queueUrl == null ? getQueueUrl(sqsClient, topic) : queueUrl;
+        this.queueUrl = queueUrl;
     }
 
     protected AbstractSqsMomProducer(SqsClient sqsClient, String topic, ObjectMapper objectMapper, Class<T> msgClass) {
@@ -57,8 +57,17 @@ public abstract class AbstractSqsMomProducer<T extends GenericEvent> implements 
         }
     }
 
-    private String getQueueUrl(SqsClient sqsClient, String topic) {
-        return sqsClient.getQueueUrl(GetQueueUrlRequest.builder().queueName(topic).build()).queueUrl();
+    protected String getQueueUrl() {
+        if (this.queueUrl == null) {
+            synchronized (this) {
+                // Double-check nel caso in cui un altro thread lo abbia valorizzato
+                // mentre questo thread aspettava il lock
+                if (this.queueUrl == null) {
+                    this.queueUrl = sqsClient.getQueueUrl(GetQueueUrlRequest.builder().queueName(topic).build()).queueUrl();
+                }
+            }
+        }
+        return this.queueUrl;
     }
 
     @Override
@@ -87,7 +96,7 @@ public abstract class AbstractSqsMomProducer<T extends GenericEvent> implements 
     protected void pushInBatch(List<SendMessageBatchRequestEntry> entries, int attempt) {
 
         SendMessageBatchResponse response = sqsClient.sendMessageBatch(SendMessageBatchRequest.builder()
-                .queueUrl(this.queueUrl)
+                .queueUrl(getQueueUrl())
                 .entries(entries)
                 .build());
 
@@ -137,7 +146,7 @@ public abstract class AbstractSqsMomProducer<T extends GenericEvent> implements 
     public void push(T message, Integer delaySeconds) {
         log.debug("Inserting data {} in SQS {} with sendMessage", message, topic);
         SendMessageRequest request = SendMessageRequest.builder()
-                .queueUrl(this.queueUrl)
+                .queueUrl(getQueueUrl())
                 .messageBody(toJson(message.getPayload()))
                 .messageAttributes(getSqSHeader(message.getHeader()))
                 .delaySeconds(delaySeconds)


### PR DESCRIPTION
- Move getQueueUrl from costructor to push method to prevent the AWS SDK from being called during the pre-training of Project Layden.
- Update pn-parent to 2.3.0-SPRINGBOOT3